### PR TITLE
DX-921 feat: Add Disclaimer to Promote Webhooks

### DIFF
--- a/components/AccountVerificationForm/AccountVerificationForm.js
+++ b/components/AccountVerificationForm/AccountVerificationForm.js
@@ -290,9 +290,22 @@ export function AccountVerificationForm() {
             </clipPath>
           </defs>
         </svg>
-        <div style={{position: "absolute", bottom: "10px", right: "left"}}>
-          &#9888; <strong>This is a demo app.</strong> 
+      {/* DISCLAIMER BANNER */}
+      <div className="fixed bottom-0 left-0 right-0 z-50 bg-yellow-300 border-yellow-400 p-3 text-center text-sm text-yellow-900 dark:bg-yellow-500 dark:border-yellow-600 dark:text-yellow-950">
+        <div className="container mx-auto flex items-center justify-center gap-2">
+          <span>
+            &#9888; <strong>This is a demo app.</strong> This app uses polling; if you want to use the webhooks app, you
+            can{" "}
+            <a
+              href="https://av-webhooks.vercel.app/"
+              className="font-medium underline hover:text-yellow-950 dark:hover:text-black"
+            >
+              use it here
+            </a>
+            .
+          </span>
         </div>
+      </div>
       </div>
 
       {/* CANCELLATION MODAL */}


### PR DESCRIPTION
## Feat: Add Disclaimer Banner to Promote Webhooks

**Key Changes:**

*   **Added Disclaimer Banner Component Logic:**
    *   Integrated a new section within `account-verification-form.js` to display a fixed banner at the bottom of the viewport.
    *   The banner includes the text: "⚠ This is a demo app. This app uses polling; if you want to use the webhooks app, you can use it here."
    *   The "use it here" text is a link (placeholder `href="#"` should be updated with the actual URL).
*   **Styling:**
    *   The banner is styled with yellow background and border colors for visibility, with distinct shades for light and dark modes to ensure it's clearly noticeable.
    *   Tailwind CSS classes are used for styling (`bg-yellow-300`, `border-yellow-400`, `text-yellow-900` for light mode, and `dark:bg-yellow-500`, `dark:border-yellow-600`, `dark:text-yellow-950` for dark mode).

**Why these changes were made:**

To clearly communicate to users the nature of the application (demo) and its current data retrieval method (polling), while also offering an alternative (webhooks app). This helps manage user expectations and provides transparency.
