### PR TITLE
DX-1008 Fix CI lint and Cypress configuration regressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "DIR=$(yarn cache dir)" >> $GITHUB_ENV
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v4
         id: yarn-cache

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require('cypress');
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
-    supportFile: 'cypress/integration/app.spec.js',
+    supportFile: 'cypress/support/index.js',
     specPattern: 'cypress/integration/**/*.js',
     setupNodeEvents(on, config) {
       // Example: require plugins if necessary

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint .",
+    "lint": "next lint",
     "cypress": "cypress open --config-file=cypress.config.js",
     "cypress:run": "cypress run --config-file=cypress.config.js"
   },


### PR DESCRIPTION
## Changes:

- Update the lint script in [package.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from next lint . to next lint so it works with the current Next.js CLI.
- Fix Cypress support file configuration in [cypress.config.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) so the support entry points to cypress/support/index.js instead of the spec file.
- Fix the GitHub Actions cache output wiring in [test.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) by writing the yarn cache directory to GITHUB_OUTPUT, which matches the later steps.<id>.outputs.dir usage.

## Why:

- next lint . is now interpreted incorrectly by the installed Next.js version and fails CI.
- Cypress was loading the test spec as its support file, which caused duplicate execution behavior.
- The lint workflow cache step referenced a step output that was never actually set.

## Validation:

- yarn lint passes locally.
- `CI=1 yarn cypress:run` passes locally when the app server is running.
- The edited workflow YAML reports no file-level errors.